### PR TITLE
Added Game entity with POST and GET endpoints

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
@@ -6,9 +7,8 @@
         <option value="$PROJECT_DIR$/pom.xml" />
       </list>
     </option>
-    <option name="workspaceImportForciblyTurnedOn" value="true" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/com/keyin/rest/game/Game.java
+++ b/src/main/java/com/keyin/rest/game/Game.java
@@ -1,0 +1,32 @@
+package com.keyin.rest.game;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+public class Game {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String homeTeam;
+    private String awayTeam;
+    private String location;
+    private LocalDate scheduledDate;
+
+    // Getters & Setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getHomeTeam() { return homeTeam; }
+    public void setHomeTeam(String homeTeam) { this.homeTeam = homeTeam; }
+
+    public String getAwayTeam() { return awayTeam; }
+    public void setAwayTeam(String awayTeam) { this.awayTeam = awayTeam; }
+
+    public String getLocation() { return location; }
+    public void setLocation(String location) { this.location = location; }
+
+    public LocalDate getScheduledDate() { return scheduledDate; }
+    public void setScheduledDate(LocalDate scheduledDate) { this.scheduledDate = scheduledDate; }
+}

--- a/src/main/java/com/keyin/rest/game/GameController.java
+++ b/src/main/java/com/keyin/rest/game/GameController.java
@@ -1,0 +1,24 @@
+package com.keyin.rest.game;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/games")
+public class GameController {
+
+    @Autowired
+    private GameRepository gameRepository;
+
+    @GetMapping
+    public List<Game> getAllGames() {
+        return gameRepository.findAll();
+    }
+
+    @PostMapping
+    public Game createGame(@RequestBody Game game) {
+        return gameRepository.save(game);
+    }
+}

--- a/src/main/java/com/keyin/rest/game/GameRepository.java
+++ b/src/main/java/com/keyin/rest/game/GameRepository.java
@@ -1,0 +1,6 @@
+package com.keyin.rest.game;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GameRepository extends JpaRepository<Game, Long> {
+}


### PR DESCRIPTION
This pull request adds a new Game entity to the hockey registration API.

`GET /games` - Retrieve all games
`POST /games` - Add a new game (home team, away team, location, and scheduled date)

Tested locally with MySQL and Postman.